### PR TITLE
feat: added pytest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ outputs/
 
 # pycharm
 .idea/
+
+# benchmark
+.benchmarks/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cmdbench==0.1.13
-memory-profiler==0.58.0
 faker==8.11.0
+memory-profiler==0.58.0
+pytest-benchmark==3.4.1

--- a/tests/test_document_array_mem_map.py
+++ b/tests/test_document_array_mem_map.py
@@ -1,0 +1,42 @@
+import os
+import uuid
+from pathlib import Path
+from jina import Document, __version__
+from jina.types.arrays.memmap import DocumentArrayMemmap
+
+
+def _get_mem_map_path():
+    mem_map_path = os.path.join(os.getcwd(), 'tmp/{}'.format(str(uuid.uuid4())))
+    Path(mem_map_path).mkdir(parents=True, exist_ok=True)
+
+    return mem_map_path
+
+
+def _get_doc_list(dam_size=1000000):
+    doc_list = []
+    dam_size = dam_size
+
+    for i in range(dam_size):
+        doc_list.append(
+            Document(
+                text=f'This is the document number: {i}',
+            )
+        )
+
+    return doc_list
+
+
+def document_array_mem_map(doc_list, mem_map_path):
+    dam = DocumentArrayMemmap(mem_map_path)
+    dam.extend(doc_list)
+
+    return len(doc_list)
+
+
+def test_document_array_mem_map(benchmark):
+    dam_size = 1000000
+    mem_map_path = _get_mem_map_path()
+    doc_list = _get_doc_list(dam_size)
+    result = benchmark(document_array_mem_map, doc_list, mem_map_path)
+
+    assert result == dam_size


### PR DESCRIPTION
# Changes:

- feat: added pytest support

# Run

```shell
$ pytest
```

# Terminal Output:

```shell
====================================================== test session starts =======================================================
platform darwin -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/maateen/Documents/workspace/jina-ai/benchmark/src
plugins: benchmark-3.4.1, Faker-8.11.0
collected 1 item

tests/test_document_array_mem_map.py .                                                                                     [100%]


--------------------------------------------------- benchmark: 1 tests ---------------------------------------------------
Name (time in s)                    Min      Max     Mean   StdDev   Median      IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------
test_document_array_mem_map     16.4552  46.1017  31.1852  11.7114  31.2898  18.4902       2;0  0.0321       5           1
--------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
================================================= 1 passed in 226.44s (0:03:46) ==================================================
```

# Terminal Comparison:

```shell
====================================================== test session starts =======================================================
platform darwin -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/maateen/Documents/workspace/jina-ai/benchmark/src
plugins: benchmark-3.4.1, Faker-8.11.0
collected 1 item

tests/test_document_array_mem_map.py .                                                                                     [100%]


---------------------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------------------------------------------
Name (time in s)                                   Min                Max               Mean             StdDev             Median                IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_document_array_mem_map (NOW)              14.5769 (1.0)      45.0612 (1.0)      29.8647 (1.0)      12.2234 (1.0)      29.9452 (1.0)      19.8527 (1.01)          2;0  0.0335 (1.0)           5           1
test_document_array_mem_map (0002_1e188ac)     14.7080 (1.01)     45.4782 (1.01)     30.7099 (1.03)     12.3167 (1.01)     32.6250 (1.09)     19.7272 (1.0)           2;0  0.0326 (0.97)          5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
================================================= 1 passed in 218.43s (0:03:38) ==================================================
```

# JSON Output:

```json
{
    "machine_info": {
        "node": "MacBooks-MacBook-Air.local",
        "processor": "i386",
        "machine": "x86_64",
        "python_compiler": "Clang 12.0.5 (clang-1205.0.22.11)",
        "python_implementation": "CPython",
        "python_implementation_version": "3.9.5",
        "python_version": "3.9.5",
        "python_build": [
            "default",
            "Jul  1 2021 20:29:44"
        ],
        "release": "20.6.0",
        "system": "Darwin",
        "cpu": {
            "python_version": "3.9.5.final.0 (64 bit)",
            "cpuinfo_version": [
                8,
                0,
                0
            ],
            "cpuinfo_version_string": "8.0.0",
            "arch": "X86_64",
            "bits": 64,
            "count": 8,
            "arch_string_raw": "x86_64",
            "brand_raw": "Apple M1",
            "hz_actual_friendly": "2.4000 GHz",
            "hz_actual": [
                2400000000,
                0
            ],
            "family": 6,
            "flags": [
                "acpi",
                "aes",
                "apic",
                "clflush",
                "clfsh",
                "cmov",
                "cx16",
                "cx8",
                "de",
                "ds",
                "dscpl",
                "dtes64",
                "dtse64",
                "est",
                "fpu",
                "fxsr",
                "htt",
                "lahf_lm",
                "mca",
                "mce",
                "mmx",
                "mon",
                "monitor",
                "msr",
                "mtrr",
                "pae",
                "pat",
                "pbe",
                "pclmulqdq",
                "pdcm",
                "pge",
                "pni",
                "popcnt",
                "pse",
                "pse36",
                "seglim64",
                "sep",
                "ss",
                "sse",
                "sse2",
                "sse3",
                "sse4.1",
                "sse4.2",
                "sse4_1",
                "sse4_2",
                "ssse3",
                "tm",
                "tm2",
                "tpr",
                "tsc",
                "vme",
                "vmx"
            ],
            "vendor_id_raw": "GenuineIntel",
            "hz_advertised_friendly": "2.5000 GHz",
            "hz_advertised": [
                2500000000,
                0
            ],
            "l2_cache_size": 65536,
            "l2_cache_line_size": 8192,
            "l2_cache_associativity": 8,
            "model": 44
        }
    },
    "commit_info": {
        "id": "1e188ac5e1e77791e78f30c080ff094f9061c6ee",
        "time": "2021-08-09T11:58:43+06:00",
        "author_time": "2021-08-09T11:58:43+06:00",
        "dirty": false,
        "project": "benchmarking",
        "branch": "feat-added-pytest-support"
    },
    "benchmarks": [
        {
            "group": null,
            "name": "test_document_array_mem_map",
            "fullname": "tests/test_document_array_mem_map.py::test_document_array_mem_map",
            "params": null,
            "param": null,
            "extra_info": {},
            "options": {
                "disable_gc": false,
                "timer": "perf_counter",
                "min_rounds": 5,
                "max_time": 1.0,
                "min_time": 5e-06,
                "warmup": false
            },
            "stats": {
                "min": 14.707988541999999,
                "max": 45.478215167,
                "mean": 30.709871408599998,
                "stddev": 12.316698549466096,
                "rounds": 5,
                "median": 32.625027083999996,
                "iqr": 19.727189406249998,
                "q1": 20.43647810425,
                "q3": 40.1636675105,
                "iqr_outliers": 0,
                "stddev_outliers": 2,
                "outliers": "2;0",
                "ld15iqr": 14.707988541999999,
                "hd15iqr": 45.478215167,
                "ops": 0.03256281951476879,
                "total": 153.549357043,
                "iterations": 1
            }
        }
    ],
    "datetime": "2021-08-09T06:03:49.000872",
    "version": "3.4.1"
}
```

# Notes:

- This PR closes ##16 
- This PR is for showcase purposes only.