### PR TITLE
feat: add print at run time

### DIFF
--- a/src/utils/benchmark.py
+++ b/src/utils/benchmark.py
@@ -65,6 +65,7 @@ def benchmark_time(
 
     m = mean(results)
     s = stdev(results) if len(results) > 1 else None
+    print(f'----> mean_time={round(m,3)}, std_time={round(s,3)}')
 
     if len(mean_profiles) > 0:
         return m, s, mean_profiles


### PR DESCRIPTION
From a practical point, when developing code for core I think it would be useful to  be able to run a fast benchmark locally and see if how the proposed changes affect  performance using the current benchmarks. 

It seems a simple print inside `benchmark_time`  would be very handy to run with `pytest -v -s`  to get direct timings from the benchmark.

This PR
```
src/document_graph_construction.py:: test_foo ----> mean_time=224.4, std_time=10.015
PASSED
src/document_graph_construction.py:: test_foo ----> mean_time=420, std_time=9.566
PASSED
```
main branch
```
src/document_graph_construction.py::test_foo
PASSED
src/document_graph_construction.py::test_foo
PASSED
```