### PR TITLE
fix: num repetitions

### DIFF
--- a/src/document_graph_construction.py
+++ b/src/document_graph_construction.py
@@ -8,7 +8,6 @@ from jina.types.document.graph import GraphDocument
 from .utils.benchmark import benchmark_time
 
 NUM_REPETITIONS = 5
-NUM_DOCS = 1000
 
 
 @pytest.mark.parametrize("n_edges", [2000, 20_000])
@@ -36,7 +35,7 @@ def test_graph_add_edges_assuming_no_nodes_present(n_nodes, n_edges, json_writer
     json_writer.append(
         dict(
             name="document_graph_construction/test_graph_add_edges_assuming_no_nodes_present",
-            iterations=NUM_DOCS,
+            iterations=NUM_REPETITIONS,
             mean_time=mean_time,
             std_time=std_time,
             unit="ms",
@@ -73,7 +72,7 @@ def test_graph_add_edges_assuming_all_nodes_present(n_nodes, n_edges, json_write
     json_writer.append(
         dict(
             name="document_graph_construction/test_graph_add_edges_assuming_all_nodes_present",
-            iterations=NUM_DOCS,
+            iterations=NUM_REPETITIONS,
             mean_time=mean_time,
             std_time=std_time,
             unit="ms",
@@ -107,7 +106,7 @@ def test_graph_add_single_edge_assuming_all_nodes_present(
     json_writer.append(
         dict(
             name="document_graph_construction/test_graph_add_single_edge_assuming_all_nodes_present",
-            iterations=NUM_DOCS,
+            iterations=NUM_REPETITIONS,
             mean_time=mean_time,
             std_time=std_time,
             unit="ms",
@@ -138,7 +137,7 @@ def test_graph_add_single_edge_assuming_no_nodes_present(n_nodes, n_edges, json_
     json_writer.append(
         dict(
             name="document_graph_construction/test_graph_add_single_edge_assuming_no_nodes_present",
-            iterations=NUM_DOCS,
+            iterations=NUM_REPETITIONS,
             mean_time=mean_time,
             std_time=std_time,
             unit="ms",
@@ -167,7 +166,7 @@ def test_graph_add_single_node(n_nodes, json_writer):
     json_writer.append(
         dict(
             name="document_graph_construction/test_graph_add_single_node",
-            iterations=NUM_DOCS,
+            iterations=NUM_REPETITIONS,
             mean_time=mean_time,
             std_time=std_time,
             unit="ms",
@@ -196,7 +195,7 @@ def test_graph_add_nodes(n_nodes, json_writer):
     json_writer.append(
         dict(
             name="document_graph_construction/test_graph_add_nodes",
-            iterations=NUM_DOCS,
+            iterations=NUM_REPETITIONS,
             mean_time=mean_time,
             std_time=std_time,
             unit="ms",


### PR DESCRIPTION
removes `NUM_DOCS` and uses `NUM_REPETITIONS` in the benchmark